### PR TITLE
feat(v4): Show empty state for Event Widget (#91)

### DIFF
--- a/src/components/calendar/CalendarEvent.tsx
+++ b/src/components/calendar/CalendarEvent.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import useMediaQuery from '../../hooks/useMediaQuery';
-import { MOBILE_WIDTH_SIZE } from '../../themes/size';
-
 interface Props {
   calendarEvent: App.Calendar.Event;
 }
 
-const Wrapper = styled.div<{ isMobile?: boolean }>`
+const Wrapper = styled.div`
   display: flex;
-  padding: ${(props) => (props.isMobile ? 4 : 8)}px 0;
   cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 0 8px;
 
   :hover {
     background-color: ${(props) => props.theme.calendar.red}12;
@@ -20,11 +20,11 @@ const Wrapper = styled.div<{ isMobile?: boolean }>`
 `;
 
 const Divider = styled.div`
-  margin: 0 12px;
+  margin-inline-end: 8px;
   background-color: ${(props) => props.theme.calendar.red};
 
   width: 4px;
-  height: 100%;
+  height: 75%;
   border-radius: 4px;
 `;
 
@@ -32,13 +32,14 @@ const TextWrapper = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
+  justify-content: center;
 `;
 
 const Title = styled.h3`
   margin: 0;
   font-weight: 600;
-  font-size: 1rem;
-  color: ${(props) => props.theme.text900};
+  font-size: 0.9em;
+  color: ${(props) => props.theme.textColor[10]};
 
   // NOTE: (hello@amostan.me) This is to truncate the title into 1 line with ellipsis
   -webkit-box-orient: vertical;
@@ -49,16 +50,17 @@ const Title = styled.h3`
 
 const Subtitle = styled.p`
   margin: 0;
-  font-size: 1rem;
-  color: ${(props) => props.theme.text600};
+  margin-top: 2px;
+  font-weight: 500;
+  font-size: 0.85em;
+  color: ${(props) => props.theme.textColor[30]};
 `;
 
 const CalendarEvent: React.FC<Props> = function (props) {
   const { calendarEvent } = props;
-  const isMobile = useMediaQuery(`(max-width: ${MOBILE_WIDTH_SIZE})`);
 
   return (
-    <Wrapper isMobile={isMobile}>
+    <Wrapper>
       <Divider />
       <TextWrapper>
         <Title>{calendarEvent.title}</Title>

--- a/src/components/widget/TodaySummary/components/Calendar.tsx
+++ b/src/components/widget/TodaySummary/components/Calendar.tsx
@@ -14,6 +14,16 @@ const Wrapper = styled.div`
   padding: 8px;
 `;
 
+const EmptyWrapper = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+`;
+
+const EmptyText = styled.p`
+  color: ${(props) => props.theme.textColor[30]};
+`;
+
 interface Props {
   events: App.Calendar.Event[];
 }
@@ -21,15 +31,22 @@ interface Props {
 const Calendar: React.FC<Props> = function (props) {
   const { events } = props;
 
-  const trimmedEvents = events.length > 3 ? events.slice(0, 3) : events;
+  const renderEvents = React.useCallback(() => {
+    if (events.length === 0) {
+      return (
+        <EmptyWrapper>
+          <EmptyText>No more events today</EmptyText>
+        </EmptyWrapper>
+      );
+    }
 
-  return (
-    <Wrapper>
-      {trimmedEvents.map((calEvent, index) => (
-        <CalendarEvent key={index} calendarEvent={calEvent} />
-      ))}
-    </Wrapper>
-  );
+    const trimmedEvents = events.length > 3 ? events.slice(0, 3) : events;
+    return trimmedEvents.map((calEvent) => (
+      <CalendarEvent key={calEvent.title} calendarEvent={calEvent} />
+    ));
+  }, [events]);
+
+  return <Wrapper>{renderEvents()}</Wrapper>;
 };
 
 export default Calendar;

--- a/src/components/widget/TodaySummary/components/Calendar.tsx
+++ b/src/components/widget/TodaySummary/components/Calendar.tsx
@@ -4,9 +4,8 @@ import styled from 'styled-components';
 import CalendarEvent from '../../../calendar/CalendarEvent';
 
 const Wrapper = styled.div`
-  background-color: #e6e6e6;
+  background-color: ${(props) => props.theme.appColor[90]};
   margin-top: 8px;
-
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/src/components/widget/TodaySummary/components/Calendar.tsx
+++ b/src/components/widget/TodaySummary/components/Calendar.tsx
@@ -6,21 +6,19 @@ import CalendarEvent from '../../../calendar/CalendarEvent';
 const Wrapper = styled.div`
   background-color: ${(props) => props.theme.appColor[90]};
   margin-top: 8px;
-  display: flex;
+  display: grid;
   flex: 1;
-  flex-direction: column;
+  grid-template-rows: repeat(3, minmax(auto, 1fr));
+  grid-gap: 4px;
 
   border-radius: 16px;
   padding: 8px;
 `;
 
-const EmptyWrapper = styled.div`
+const EmptyWrapper = styled(Wrapper)`
   display: flex;
   flex: 1;
   align-items: center;
-`;
-
-const EmptyText = styled.p`
   color: ${(props) => props.theme.textColor[30]};
 `;
 
@@ -31,22 +29,18 @@ interface Props {
 const Calendar: React.FC<Props> = function (props) {
   const { events } = props;
 
-  const renderEvents = React.useCallback(() => {
-    if (events.length === 0) {
-      return (
-        <EmptyWrapper>
-          <EmptyText>No more events today</EmptyText>
-        </EmptyWrapper>
-      );
-    }
+  if (events.length === 0) {
+    return <EmptyWrapper>No events today</EmptyWrapper>;
+  }
 
-    const trimmedEvents = events.length > 3 ? events.slice(0, 3) : events;
-    return trimmedEvents.map((calEvent) => (
-      <CalendarEvent key={calEvent.title} calendarEvent={calEvent} />
-    ));
-  }, [events]);
-
-  return <Wrapper>{renderEvents()}</Wrapper>;
+  const trimmedEvents = events.length > 3 ? events.slice(0, 3) : events;
+  return (
+    <Wrapper>
+      {trimmedEvents.map((calEvent) => (
+        <CalendarEvent key={calEvent.title} calendarEvent={calEvent} />
+      ))}
+    </Wrapper>
+  );
 };
 
 export default Calendar;

--- a/src/components/widget/TodaySummary/components/TodayEvent.tsx
+++ b/src/components/widget/TodaySummary/components/TodayEvent.tsx
@@ -24,6 +24,7 @@ const DaysWrapper = styled.div`
   flex-direction: row;
   align-items: flex-end;
   padding-bottom: 8px;
+  color: ${(props) => props.theme.textColor[10]};
 
   span {
     font-weight: 600;

--- a/src/components/widget/TodaySummary/components/TodaysSummary.tsx
+++ b/src/components/widget/TodaySummary/components/TodaysSummary.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 const Wrapper = styled.div`
   margin-top: 8px;
   font-weight: 600;
-  color: ${(props) => props.theme.text600};
+  color: ${(props) => props.theme.textColor[30]};
 
   span {
     margin: 0;


### PR DESCRIPTION
Issue #91 

## Purpose

This PR updates the stylings of the Today Events widget. It also adds an empty state "No events today" 

## Demo
<img width="1002" alt="ClassMaid Demo" src="https://github.com/foldaway/smu-shortcuts/assets/8110786/96860dce-fe69-4571-a895-97ba46d21517">

